### PR TITLE
feat: add ethereum property to Window interface for MetaMask support

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -11,6 +11,10 @@ interface TelegramWebApp {
 }
 
 interface Window {
+  ethereum?: {
+    isMetaMask?: boolean
+    request: (args: { method: string; params?: any[] }) => Promise<any>
+  }
   Telegram: {
     WebApp: TelegramWebApp
   }


### PR DESCRIPTION
feat: add ethereum property to Window interface for MetaMask support

The `ethereum` property was added to the `Window` interface to enable support 
for detecting and interacting with MetaMask. This includes:
- Checking if MetaMask is installed (`isMetaMask`).
- Sending JSON-RPC requests via the `request` method.